### PR TITLE
changed solidity parser to parse assembly if

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "req-cwd": "^1.0.1",
     "shelljs": "^0.7.4",
     "sol-explore": "^1.6.2",
-    "solidity-parser-sc": "maxsam4/solidity-parser#solidity-0.5",
+    "solidity-parser-sc": "https://github.com/leekt216/solidity-parser",
     "tree-kill": "^1.2.0",
     "web3": "^0.20.6"
   },


### PR DESCRIPTION
original solidity parser was not able to parse assembly if properly and throw error while instrumenting
simple addition on solidity parser can fix this problem